### PR TITLE
feat: fix drag-drop upload and add marker edit page

### DIFF
--- a/app/Http/Controllers/ArMarkerController.php
+++ b/app/Http/Controllers/ArMarkerController.php
@@ -53,6 +53,57 @@ class ArMarkerController extends Controller
             ->with('success', 'Marker AR berhasil diupload.');
     }
 
+    public function edit(ArMarker $marker): View
+    {
+        $disasters = Disaster::orderBy('name')->get();
+
+        return view('admin.markers.edit', compact('marker', 'disasters'));
+    }
+
+    public function update(Request $request, ArMarker $marker)
+    {
+        $request->validate([
+            'nama' => 'required|string|max:255',
+            'disaster_id' => 'nullable|integer|exists:disasters,id',
+            'path_gambar_marker' => 'nullable|image|mimes:jpeg,png,jpg,gif,webp|max:5120',
+            'path_model' => 'nullable|file|mimes:glb,gltf,binary|max:20480',
+        ]);
+
+        $marker->nama = $request->nama;
+        $marker->disaster_id = $request->disaster_id;
+
+        // Handle gambar marker baru — hapus file lama + generate ulang .patt
+        if ($request->hasFile('path_gambar_marker')) {
+            $this->deletePublicFile($marker->path_gambar_marker);
+            $this->deletePublicFile($marker->path_patt);
+
+            $markerData = $this->storeMarkerAssets(
+                $request->file('path_gambar_marker'),
+                $request->file('path_model')
+            );
+
+            $marker->path_gambar_marker = $markerData['path_gambar_marker'];
+            $marker->path_patt = $markerData['path_patt'];
+            $marker->path_model = $markerData['path_model'] ?? $marker->path_model;
+        }
+
+        // Handle model saja diubah (tanpa ganti gambar)
+        if (!$request->hasFile('path_gambar_marker') && $request->hasFile('path_model')) {
+            $this->deletePublicFile($marker->path_model);
+
+            $modelFile = $request->file('path_model');
+            $ext = $modelFile->getClientOriginalExtension() ?: 'glb';
+            $modelPath = 'ar-markers/models/'.$marker->marker_id.'_model_'.now()->format('YmdHis').'.'.$ext;
+            Storage::disk('public')->put($modelPath, file_get_contents($modelFile->getRealPath()));
+            $marker->path_model = $modelPath;
+        }
+
+        $marker->save();
+
+        return redirect()->route('admin.markers.index')
+            ->with('success', 'Marker AR berhasil diperbarui.');
+    }
+
     public function destroy(ArMarker $marker)
     {
         $this->deletePublicFile($marker->path_gambar_marker);

--- a/resources/views/admin/markers/edit.blade.php
+++ b/resources/views/admin/markers/edit.blade.php
@@ -1,8 +1,8 @@
 @extends('admin._layout')
 
-@section('title', 'Upload Marker AR')
-@section('page-title', 'Upload Marker AR')
-@section('page-subtitle', 'Upload gambar marker AR untuk simulasi bencana')
+@section('title', 'Edit Marker AR')
+@section('page-title', 'Edit Marker AR')
+@section('page-subtitle', 'Ubah data marker AR')
 
 @section('header-actions')
     <a href="{{ route('admin.markers.index') }}"
@@ -15,15 +15,16 @@
 
     <div class="max-w-2xl">
 
-        <form method="POST" action="{{ route('admin.markers.store') }}" enctype="multipart/form-data"
+        <form method="POST" action="{{ route('admin.markers.update', $marker) }}" enctype="multipart/form-data"
             class="space-y-5 rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
 
             @csrf
+            @method('PUT')
 
             <div>
                 <label class="mb-1.5 block text-sm font-semibold text-gray-700">Nama Marker <span
                         class="text-red-500">*</span></label>
-                <input type="text" name="nama" value="{{ old('nama') }}" required autofocus
+                <input type="text" name="nama" value="{{ old('nama', $marker->nama) }}" required autofocus
                     placeholder="Contoh: Marker Banjir"
                     class="@error('nama') @enderror w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm text-gray-900 placeholder-gray-400 focus:border-[#c25c06] focus:outline-none focus:ring-2 focus:ring-[#c25c06]/20">
                 @error('nama')
@@ -37,7 +38,8 @@
                     class="@error('disaster_id') @enderror w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm text-gray-900 focus:border-[#c25c06] focus:outline-none focus:ring-2 focus:ring-[#c25c06]/20">
                     <option value="">-- Pilih Bencana --</option>
                     @foreach ($disasters as $disaster)
-                        <option value="{{ $disaster->id }}" {{ old('disaster_id') == $disaster->id ? 'selected' : '' }}>
+                        <option value="{{ $disaster->id }}"
+                            {{ old('disaster_id', $marker->disaster_id) == $disaster->id ? 'selected' : '' }}>
                             {{ $disaster->name }}
                         </option>
                     @endforeach
@@ -48,18 +50,19 @@
             </div>
 
             <div>
-                <label class="mb-1.5 block text-sm font-semibold text-gray-700">Gambar Marker AR <span
-                        class="text-red-500">*</span></label>
+                <label class="mb-1.5 block text-sm font-semibold text-gray-700">Gambar Marker AR</label>
                 <div id="marker-drop-zone"
                     class="rounded-lg border-2 border-dashed border-gray-300 p-6 text-center transition-colors hover:border-[#c25c06]">
                     <input type="file" name="path_gambar_marker" id="path_gambar_marker" accept="image/*"
                         class="@error('path_gambar_marker') border-red-500 @enderror hidden"
                         onchange="previewMarkerImage(this)">
                     <label for="path_gambar_marker" class="flex cursor-pointer flex-col items-center gap-3">
-                        <div id="preview-container" class="hidden">
-                            <img id="preview-image" class="mx-auto max-h-48 rounded-lg shadow">
+                        <div id="preview-container" @if (!$marker->path_gambar_marker) class="hidden" @endif>
+                            <img id="preview-image"
+                                 src="{{ $marker->path_gambar_marker ? Storage::disk('public')->url($marker->path_gambar_marker) : '' }}"
+                                 class="mx-auto max-h-48 rounded-lg shadow">
                         </div>
-                        <div id="upload-placeholder">
+                        <div id="upload-placeholder" @if ($marker->path_gambar_marker) class="hidden" @endif>
                             <svg class="mx-auto h-12 w-12 text-gray-300" fill="none" stroke="currentColor"
                                 viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
@@ -70,6 +73,7 @@
                     </label>
                 </div>
                 <p class="mt-2 text-xs text-gray-400">
+                    Kosongkan jika tidak ingin mengubah gambar.
                     Gunakan gambar dengan kontras tinggi dan detail visual jelas. Minimal 512×512 pixel.
                     Format: JPEG, PNG, JPG, GIF, WebP. Maksimal 5MB.
                 </p>
@@ -85,15 +89,17 @@
                     <input type="file" name="path_model" id="path_model" accept=".glb,.gltf,.binary"
                         class="@error('path_model') border-red-500 @enderror hidden" onchange="previewModelFile(this)">
                     <label for="path_model" class="flex cursor-pointer flex-col items-center gap-3">
-                        <div id="model-preview-container" class="hidden">
+                        <div id="model-preview-container" @if (!$marker->path_model) class="hidden" @endif>
                             <svg class="mx-auto h-10 w-10 text-green-500" fill="none" stroke="currentColor"
                                 viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                                     d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
                             </svg>
-                            <p id="model-filename" class="mt-2 text-sm font-medium text-green-600"></p>
+                            <p id="model-filename" class="mt-2 text-sm font-medium text-green-600">
+                                {{ $marker->path_model ? basename($marker->path_model) : '' }}
+                            </p>
                         </div>
-                        <div id="model-placeholder">
+                        <div id="model-placeholder" @if ($marker->path_model) class="hidden" @endif>
                             <svg class="mx-auto h-10 w-10 text-gray-300" fill="none" stroke="currentColor"
                                 viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
@@ -104,8 +110,8 @@
                     </label>
                 </div>
                 <p class="mt-2 text-xs text-gray-400">
-                    Model 3D berekstensi .glb atau .gltf yang akan ditampilkan di marker.
-                    Maksimal 20MB. Jika tidak diupload, akan ditampilkan kubus placeholder.
+                    Kosongkan jika tidak ingin mengubah model 3D.
+                    Maksimal 20MB.
                 </p>
                 @error('path_model')
                     <p class="mt-1 text-xs text-red-600">{{ $message }}</p>
@@ -115,7 +121,7 @@
             <div class="flex items-center gap-3 pt-2">
                 <button type="submit"
                     class="rounded-lg bg-[#c25c06] px-6 py-2.5 text-sm font-bold text-white transition-colors hover:bg-[#a04a05]">
-                    Upload Marker
+                    Simpan Perubahan
                 </button>
                 <a href="{{ route('admin.markers.index') }}"
                     class="rounded-lg border border-gray-300 bg-white px-6 py-2.5 text-sm font-semibold text-gray-700 transition-colors hover:bg-gray-50">

--- a/resources/views/admin/markers/index.blade.php
+++ b/resources/views/admin/markers/index.blade.php
@@ -64,15 +64,21 @@
                             @endif
                         </td>
                         <td class="px-6 py-4">
-                            <form method="POST" action="{{ route('admin.markers.destroy', $marker) }}"
-                                onsubmit="return confirm('Hapus marker &quot;{{ $marker->nama ?? $marker->marker_id }}&quot;?')">
-                                @csrf
-                                @method('DELETE')
-                                <button type="submit"
-                                    class="rounded-lg border border-red-200 bg-white px-3 py-1.5 text-xs font-semibold text-red-600 hover:bg-red-50 hover:border-red-400 transition-colors">
-                                    Hapus
-                                </button>
-                            </form>
+                            <div class="flex items-center gap-2">
+                                <a href="{{ route('admin.markers.edit', $marker) }}"
+                                    class="rounded-lg border border-blue-200 bg-white px-3 py-1.5 text-xs font-semibold text-blue-600 hover:bg-blue-50 hover:border-blue-400 transition-colors">
+                                    Edit
+                                </a>
+                                <form method="POST" action="{{ route('admin.markers.destroy', $marker) }}"
+                                    onsubmit="return confirm('Hapus marker &quot;{{ $marker->nama ?? $marker->marker_id }}&quot;?')">
+                                    @csrf
+                                    @method('DELETE')
+                                    <button type="submit"
+                                        class="rounded-lg border border-red-200 bg-white px-3 py-1.5 text-xs font-semibold text-red-600 hover:bg-red-50 hover:border-red-400 transition-colors">
+                                        Hapus
+                                    </button>
+                                </form>
+                            </div>
                         </td>
                     </tr>
                 @empty

--- a/routes/web.php
+++ b/routes/web.php
@@ -31,6 +31,8 @@ Route::middleware('auth')->prefix('admin')->group(function () {
     Route::get('/markers', [ArMarkerController::class, 'index'])->name('admin.markers.index');
     Route::get('/markers/create', [ArMarkerController::class, 'create'])->name('admin.markers.create');
     Route::post('/markers', [ArMarkerController::class, 'store'])->name('admin.markers.store');
+    Route::get('/markers/{marker}/edit', [ArMarkerController::class, 'edit'])->name('admin.markers.edit');
+    Route::put('/markers/{marker}', [ArMarkerController::class, 'update'])->name('admin.markers.update');
     Route::delete('/markers/{marker}', [ArMarkerController::class, 'destroy'])->name('admin.markers.destroy');
 });
 


### PR DESCRIPTION
## Summary

- **Fix**: Drag & drop file upload pada halaman create marker tidak berfungsi (browser membuka file alih-alih mengupload)
- **Fitur**: Tambah halaman edit marker AR untuk mengubah nama, gambar marker, dan model 3D

## Detail Perubahan

### Fix: Drag & Drop Upload
- Tambahkan JS event listener (`dragenter`, `dragover`, `dragleave`, `drop`) pada drop zone gambar marker dan model 3D
- File yang di-drop di-assign ke `<input type="file">` secara programatik dan trigger `change` event

### Fitur: Halaman Edit Marker
- Tambah route `GET /markers/{marker}/edit` dan `PUT /markers/{marker}`
- Tambah method `edit()` dan `update()` di `ArMarkerController`
- `update()` handle 3 kasus:
  1. Gambar diubah → hapus file lama + generate ulang `.patt`
  2. Model saja diubah → replace file model lama
  3. Nama/bencana saja diubah → update kolom saja
- Buat `resources/views/admin/markers/edit.blade.php` dengan form pre-filled + drag-drop support
- Tambah tombol "Edit" di kolom aksi tabel index

## Test plan
- [ ] Drag & drop upload gambar marker
- [ ] Drag & drop upload model 3D
- [ ] Edit nama marker saja
- [ ] Edit gambar marker (verifikasi .patt di-regenerate)
- [ ] Edit model 3D saja
- [ ] Hapus marker (verifikasi file lama dihapus dari storage)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added full edit functionality for AR markers with the ability to update marker images and 3D model files
  * Implemented drag-and-drop file upload support for marker images and model files with real-time preview
  * Added edit action link to the AR markers list for quick access to editing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->