### PR TITLE
feat: add audio support for AR markers

### DIFF
--- a/app/Http/Controllers/ArMarkerController.php
+++ b/app/Http/Controllers/ArMarkerController.php
@@ -34,11 +34,26 @@ class ArMarkerController extends Controller
             'nama' => 'nullable|string|max:255',
             'path_gambar_marker' => 'required|image|mimes:jpeg,png,jpg,gif,webp|max:5120',
             'path_model' => 'nullable|file|mimes:glb,gltf,binary|max:20480',
+            'path_audio' => 'nullable|file|mimes:mp3,wav,ogg,webm|max:10240',
         ]);
+
+        $timestamp = now()->format('YmdHis');
+        $originalName = preg_replace('/[^a-zA-Z0-9\._-]/', '', $request->file('path_gambar_marker')->getClientOriginalName());
+        $baseName = preg_replace('/[^a-zA-Z0-9_-]/', '', pathinfo($originalName, PATHINFO_FILENAME)) ?: 'marker';
+
+        $audioPath = null;
+        if ($request->hasFile('path_audio')) {
+            $audioFile = $request->file('path_audio');
+            $ext = $audioFile->getClientOriginalExtension() ?: 'mp3';
+            $audioPath = 'ar-markers/audio/'.$timestamp.'_audio_'.$baseName.'.'.$ext;
+            Storage::disk('public')->put($audioPath, file_get_contents($audioFile->getRealPath()));
+        }
 
         $markerData = $this->storeMarkerAssets(
             $request->file('path_gambar_marker'),
-            $request->file('path_model')
+            $request->file('path_model'),
+            $timestamp,
+            $baseName
         );
 
         ArMarker::create([
@@ -47,6 +62,7 @@ class ArMarkerController extends Controller
             'path_gambar_marker' => $markerData['path_gambar_marker'],
             'path_patt' => $markerData['path_patt'],
             'path_model' => $markerData['path_model'] ?? null,
+            'path_audio' => $audioPath,
         ]);
 
         return redirect()->route('admin.markers.index')
@@ -67,6 +83,7 @@ class ArMarkerController extends Controller
             'disaster_id' => 'nullable|integer|exists:disasters,id',
             'path_gambar_marker' => 'nullable|image|mimes:jpeg,png,jpg,gif,webp|max:5120',
             'path_model' => 'nullable|file|mimes:glb,gltf,binary|max:30720',
+            'path_audio' => 'nullable|file|mimes:mp3,wav,ogg,webm|max:10240',
         ]);
 
         $marker->nama = $request->nama;
@@ -98,6 +115,17 @@ class ArMarkerController extends Controller
             $marker->path_model = $modelPath;
         }
 
+        // Handle audio baru
+        if ($request->hasFile('path_audio')) {
+            $this->deletePublicFile($marker->path_audio);
+
+            $audioFile = $request->file('path_audio');
+            $ext = $audioFile->getClientOriginalExtension() ?: 'mp3';
+            $audioPath = 'ar-markers/audio/'.$marker->marker_id.'_audio_'.now()->format('YmdHis').'.'.$ext;
+            Storage::disk('public')->put($audioPath, file_get_contents($audioFile->getRealPath()));
+            $marker->path_audio = $audioPath;
+        }
+
         $marker->save();
 
         return redirect()->route('admin.markers.index')
@@ -106,6 +134,7 @@ class ArMarkerController extends Controller
 
     public function destroy(ArMarker $marker)
     {
+        $this->deletePublicFile($marker->path_audio);
         $this->deletePublicFile($marker->path_gambar_marker);
         $this->deletePublicFile($marker->path_patt);
         $this->deletePublicFile($marker->path_model);
@@ -150,11 +179,11 @@ class ArMarkerController extends Controller
             ->deleteFileAfterSend(true);
     }
 
-    private function storeMarkerAssets($file, $modelFile = null): array
+    private function storeMarkerAssets($file, $modelFile = null, $timestamp = null, $baseName = null): array
     {
+        $timestamp = $timestamp ?? now()->format('YmdHis');
         $originalName = preg_replace('/[^a-zA-Z0-9\._-]/', '', $file->getClientOriginalName());
-        $baseName = preg_replace('/[^a-zA-Z0-9_-]/', '', pathinfo($originalName, PATHINFO_FILENAME)) ?: 'marker';
-        $timestamp = now()->format('YmdHis');
+        $baseName = $baseName ?? (preg_replace('/[^a-zA-Z0-9_-]/', '', pathinfo($originalName, PATHINFO_FILENAME)) ?: 'marker');
 
         $markerPath = null;
         $patternPath = null;

--- a/app/Models/ArMarker.php
+++ b/app/Models/ArMarker.php
@@ -19,6 +19,7 @@ class ArMarker extends Model
         'path_gambar_marker',
         'path_patt',
         'path_model',
+        'path_audio',
     ];
 
     protected $casts = [

--- a/database/migrations/2026_04_07_000000_add_path_audio_to_ar_marker_table.php
+++ b/database/migrations/2026_04_07_000000_add_path_audio_to_ar_marker_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('ar_marker', function (Blueprint $table) {
+            $table->string('path_audio', 255)->nullable()->after('path_model');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('ar_marker', function (Blueprint $table) {
+            $table->dropColumn('path_audio');
+        });
+    }
+};

--- a/public/js/ar-loader.js
+++ b/public/js/ar-loader.js
@@ -11,6 +11,7 @@
 // ── State ────────────────────────────────────────────────────────────────────
 var markerVisibilityVersion = new Map(); // markerId → integer counter
 var modelStates = new Map();              // modelSrc → { loaded, object3D, animations }
+var audioElements = new Map();            // audioSrc → HTMLAudioElement
 var globalClock = null;
 var _arAnimationMixers = [];             // central mixer list, updated by scene component
 
@@ -70,6 +71,7 @@ function isMarkerLoadStillRelevant(markerId, visibilityVersion) {
 function parseMarkerModelData(marker) {
   return {
     modelSrc: marker.getAttribute('data-model-src') || null,
+    audioSrc: marker.getAttribute('data-audio-src') || null,
     modelScale: marker.getAttribute('data-model-scale') || '1 1 1',
     modelPosition: marker.getAttribute('data-model-position') || '0 0.25 0',
   };
@@ -157,6 +159,16 @@ function loadGLB(modelSrc, markerId, visibilityVersion) {
         }
 
         updateProgress(100);
+
+        // Download audio after GLB loaded
+        var audioSrc = parseMarkerModelData(document.getElementById(markerId)).audioSrc;
+        if (audioSrc && !audioElements.has(audioSrc)) {
+          var audio = new Audio();
+          audio.src = audioSrc;
+          audio.preload = 'auto';
+          audioElements.set(audioSrc, audio);
+        }
+
         resolve(gltf);
       },
       function (e) {
@@ -212,8 +224,6 @@ function initMarkerListeners() {
     var modelSrc = parseMarkerModelData(marker).modelSrc;
 
     marker.addEventListener('markerFound', function () {
-      if (!modelSrc) return;
-
       var version = bumpMarkerVisibilityVersion(markerId);
       showLoading();
       updateProgress(5);
@@ -228,19 +238,33 @@ function initMarkerListeners() {
         }
         updateProgress(100);
         hideLoading();
-        return;
+      } else if (modelSrc) {
+        loadGLB(modelSrc, markerId, version)
+          .then(function () {
+            updateProgress(100);
+            hideLoading();
+          })
+          .catch(function (err) {
+            console.error('[ar-loader] Gagal load model untuk', markerId, err);
+            updateProgress(100);
+            hideLoading();
+          });
+      } else {
+        updateProgress(100);
+        hideLoading();
       }
 
-      loadGLB(modelSrc, markerId, version)
-        .then(function () {
-          updateProgress(100);
-          hideLoading();
-        })
-        .catch(function (err) {
-          console.error('[ar-loader] Gagal load model untuk', markerId, err);
-          updateProgress(100);
-          hideLoading();
-        });
+      // Play audio when marker found
+      var audioSrc = parseMarkerModelData(marker).audioSrc;
+      if (audioSrc) {
+        var audio = audioElements.get(audioSrc);
+        if (audio) {
+          audio.currentTime = 0;
+          audio.play().catch(function(e) {
+            console.warn('[ar-loader] Audio play failed:', e.message);
+          });
+        }
+      }
     });
 
     marker.addEventListener('markerLost', function () {
@@ -250,6 +274,15 @@ function initMarkerListeners() {
       var cached = modelStates.get(modelSrc);
       if (cached && cached.mixer) {
         cached.mixer.timeScale = 0;
+      }
+
+      // Pause audio when marker lost
+      var audioSrc = parseMarkerModelData(marker).audioSrc;
+      if (audioSrc) {
+        var audio = audioElements.get(audioSrc);
+        if (audio) {
+          audio.pause();
+        }
       }
     });
   });

--- a/resources/views/admin/markers/create.blade.php
+++ b/resources/views/admin/markers/create.blade.php
@@ -112,6 +112,39 @@
                 @enderror
             </div>
 
+            <div>
+                <label class="mb-1.5 block text-sm font-semibold text-gray-700">Audio (.mp3 / .wav)</label>
+                <div id="audio-drop-zone"
+                    class="rounded-lg border-2 border-dashed border-gray-300 p-6 text-center transition-colors hover:border-[#c25c06]">
+                    <input type="file" name="path_audio" id="path_audio" accept=".mp3,.wav,.ogg,.webm"
+                        class="@error('path_audio') border-red-500 @enderror hidden" onchange="previewAudioFile(this)">
+                    <label for="path_audio" class="flex cursor-pointer flex-col items-center gap-3">
+                        <div id="audio-preview-container" class="hidden">
+                            <svg class="mx-auto h-10 w-10 text-green-500" fill="none" stroke="currentColor"
+                                viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                    d="M9 19V6l12-3m0 0l-9-3m9 3v12m-9-3l9 3m-9-3l9 3" />
+                            </svg>
+                            <p id="audio-filename" class="mt-2 text-sm font-medium text-green-600"></p>
+                        </div>
+                        <div id="audio-placeholder">
+                            <svg class="mx-auto h-10 w-10 text-gray-300" fill="none" stroke="currentColor"
+                                viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
+                                    d="M9 19V6l12-3m0 0l-9-3m9 3v12m-9-3l9 3m-9-3l9 3" />
+                            </svg>
+                            <p class="mt-2 text-sm text-gray-500">Klik untuk pilih file audio (opsional)</p>
+                        </div>
+                    </label>
+                </div>
+                <p class="mt-2 text-xs text-gray-400">
+                    Audio diputar saat marker terdeteksi. Maksimal 10MB.
+                </p>
+                @error('path_audio')
+                    <p class="mt-1 text-xs text-red-600">{{ $message }}</p>
+                @enderror
+            </div>
+
             <div class="flex items-center gap-3 pt-2">
                 <button type="submit"
                     class="rounded-lg bg-[#c25c06] px-6 py-2.5 text-sm font-bold text-white transition-colors hover:bg-[#a04a05]">
@@ -149,6 +182,15 @@
                 document.getElementById('model-filename').textContent = file.name;
                 document.getElementById('model-preview-container').classList.remove('hidden');
                 document.getElementById('model-placeholder').classList.add('hidden');
+            }
+        }
+
+        function previewAudioFile(input) {
+            var file = input.files[0];
+            if (file) {
+                document.getElementById('audio-filename').textContent = file.name;
+                document.getElementById('audio-preview-container').classList.remove('hidden');
+                document.getElementById('audio-placeholder').classList.add('hidden');
             }
         }
 
@@ -204,6 +246,34 @@
                 if (files.length > 0) {
                     Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'files').set.call(modelInput, files);
                     modelInput.dispatchEvent(new Event('change', { bubbles: true }));
+                }
+            });
+        }
+
+        // --- Drag & Drop for Audio ---
+        var audioDropZone = document.getElementById('audio-drop-zone');
+        var audioInput = document.getElementById('path_audio');
+
+        if (audioDropZone && audioInput) {
+            ['dragenter', 'dragover'].forEach(function(eventName) {
+                audioDropZone.addEventListener(eventName, function(e) {
+                    e.preventDefault();
+                    audioDropZone.classList.add('border-[#c25c06]', 'bg-[#c25c06]/5');
+                }, false);
+            });
+
+            ['dragleave', 'drop'].forEach(function(eventName) {
+                audioDropZone.addEventListener(eventName, function(e) {
+                    e.preventDefault();
+                    audioDropZone.classList.remove('border-[#c25c06]', 'bg-[#c25c06]/5');
+                }, false);
+            });
+
+            audioDropZone.addEventListener('drop', function(e) {
+                var files = e.dataTransfer.files;
+                if (files.length > 0) {
+                    Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'files').set.call(audioInput, files);
+                    audioInput.dispatchEvent(new Event('change', { bubbles: true }));
                 }
             });
         }

--- a/resources/views/admin/markers/edit.blade.php
+++ b/resources/views/admin/markers/edit.blade.php
@@ -118,6 +118,42 @@
                 @enderror
             </div>
 
+            <div>
+                <label class="mb-1.5 block text-sm font-semibold text-gray-700">Audio (.mp3 / .wav)</label>
+                <div id="audio-drop-zone"
+                    class="rounded-lg border-2 border-dashed border-gray-300 p-6 text-center transition-colors hover:border-[#c25c06]">
+                    <input type="file" name="path_audio" id="path_audio" accept=".mp3,.wav,.ogg,.webm"
+                        class="@error('path_audio') border-red-500 @enderror hidden" onchange="previewAudioFile(this)">
+                    <label for="path_audio" class="flex cursor-pointer flex-col items-center gap-3">
+                        <div id="audio-preview-container" @if (!$marker->path_audio) class="hidden" @endif>
+                            <svg class="mx-auto h-10 w-10 text-green-500" fill="none" stroke="currentColor"
+                                viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                    d="M9 19V6l12-3m0 0l-9-3m9 3v12m-9-3l9 3m-9-3l9 3" />
+                            </svg>
+                            <p id="audio-filename" class="mt-2 text-sm font-medium text-green-600">
+                                {{ $marker->path_audio ? basename($marker->path_audio) : '' }}
+                            </p>
+                        </div>
+                        <div id="audio-placeholder" @if ($marker->path_audio) class="hidden" @endif>
+                            <svg class="mx-auto h-10 w-10 text-gray-300" fill="none" stroke="currentColor"
+                                viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
+                                    d="M9 19V6l12-3m0 0l-9-3m9 3v12m-9-3l9 3m-9-3l9 3" />
+                            </svg>
+                            <p class="mt-2 text-sm text-gray-500">Klik untuk pilih file audio (opsional)</p>
+                        </div>
+                    </label>
+                </div>
+                <p class="mt-2 text-xs text-gray-400">
+                    Kosongkan jika tidak ingin mengubah audio.
+                    Maksimal 10MB.
+                </p>
+                @error('path_audio')
+                    <p class="mt-1 text-xs text-red-600">{{ $message }}</p>
+                @enderror
+            </div>
+
             <div class="flex items-center gap-3 pt-2">
                 <button type="submit"
                     class="rounded-lg bg-[#c25c06] px-6 py-2.5 text-sm font-bold text-white transition-colors hover:bg-[#a04a05]">
@@ -155,6 +191,15 @@
                 document.getElementById('model-filename').textContent = file.name;
                 document.getElementById('model-preview-container').classList.remove('hidden');
                 document.getElementById('model-placeholder').classList.add('hidden');
+            }
+        }
+
+        function previewAudioFile(input) {
+            var file = input.files[0];
+            if (file) {
+                document.getElementById('audio-filename').textContent = file.name;
+                document.getElementById('audio-preview-container').classList.remove('hidden');
+                document.getElementById('audio-placeholder').classList.add('hidden');
             }
         }
 
@@ -210,6 +255,34 @@
                 if (files.length > 0) {
                     Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'files').set.call(modelInput, files);
                     modelInput.dispatchEvent(new Event('change', { bubbles: true }));
+                }
+            });
+        }
+
+        // --- Drag & Drop for Audio ---
+        var audioDropZone = document.getElementById('audio-drop-zone');
+        var audioInput = document.getElementById('path_audio');
+
+        if (audioDropZone && audioInput) {
+            ['dragenter', 'dragover'].forEach(function(eventName) {
+                audioDropZone.addEventListener(eventName, function(e) {
+                    e.preventDefault();
+                    audioDropZone.classList.add('border-[#c25c06]', 'bg-[#c25c06]/5');
+                }, false);
+            });
+
+            ['dragleave', 'drop'].forEach(function(eventName) {
+                audioDropZone.addEventListener(eventName, function(e) {
+                    e.preventDefault();
+                    audioDropZone.classList.remove('border-[#c25c06]', 'bg-[#c25c06]/5');
+                }, false);
+            });
+
+            audioDropZone.addEventListener('drop', function(e) {
+                var files = e.dataTransfer.files;
+                if (files.length > 0) {
+                    Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'files').set.call(audioInput, files);
+                    audioInput.dispatchEvent(new Event('change', { bubbles: true }));
                 }
             });
         }

--- a/resources/views/ar-camera.blade.php
+++ b/resources/views/ar-camera.blade.php
@@ -78,6 +78,7 @@
                 data-marker-name="{{ $marker->nama }}" data-disaster-name="{{ $marker->disaster?->name ?? '' }}"
                 data-disaster-description="{{ $marker->disaster?->description ?? '' }}"
                 data-model-src="{{ $marker->path_model ? '/storage/' . $marker->path_model : '' }}"
+                data-audio-src="{{ $marker->path_audio ? '/storage/' . $marker->path_audio : '' }}"
                 data-model-scale="1 1 1" data-model-position="0 0.25 0">
                 <a-entity id="marker{{ $marker->marker_id }}-entity" position="0 0 0" scale="1 1 1" class="clickable"
                     gesture-handler>


### PR DESCRIPTION
## Summary

- Add `path_audio` column to `ar_marker` table via migration
- Update `ArMarker` model with `path_audio` in `$fillable`
- Update `ArMarkerController` with audio upload handling in `store()`, `update()`, and `destroy()`
- Add audio file input with drag & drop and preview to admin marker create/edit forms
- Add `data-audio-src` attribute to `<a-marker>` in AR camera view
- Update `ar-loader.js` to download, cache, and play/pause audio on markerFound/markerLost

## Test plan

- [X] Run `php artisan migrate` to apply the new column
- [X] Ensure `php artisan storage:link` is in place for audio file serving
- [X] Create a new marker with an audio file via admin form
- [X] Edit an existing marker to add/update/remove audio
- [ ] Verify audio plays automatically when the marker is detected in AR camera
- [ ] Verify audio pauses when the marker is lost
- [x] Verify audio file is deleted when marker is deleted

Closes #8