### PR TITLE
fix: separate audio preloading from GLB loading

### DIFF
--- a/public/js/ar-loader.js
+++ b/public/js/ar-loader.js
@@ -88,6 +88,19 @@ function preloadAudioForMarker(marker) {
   var audioSrc = parseMarkerModelData(marker).audioSrc;
   if (!audioSrc) return;
 
+  // Basic URL validation before attempting decode
+  var trimmed = audioSrc.trim();
+  if (!trimmed) {
+    console.warn('[ar-loader] Skipping empty audioSrc for marker:', marker.id);
+    return;
+  }
+  try {
+    new URL(trimmed); // throws if invalid relative/absolute URL
+  } catch(e) {
+    console.warn('[ar-loader] Invalid audioSrc URL — skipping preload:', audioSrc);
+    return;
+  }
+
   // Pre-decode ke AudioBuffer — dilakukan di background saat AR scene dimuat.
   // Setelah ini, playAudioWhenReady() akan langsung pakai cache (tanpa fetch lagi).
   decodeAudioToBuffer(audioSrc).then(function() {
@@ -119,14 +132,11 @@ function getAudioContext() {
 }
 
 // Set volume 0 (mute) atau 1 (unmute) via GainNode
+// Always updates audioMuted even if masterGain is null so UI state stays consistent
 function setMasterVolume(unmuted) {
-  if (!masterGain) return;
-  if (unmuted) {
-    masterGain.gain.setValueAtTime(1, audioContext.currentTime);
-    audioMuted = false;
-  } else {
-    masterGain.gain.setValueAtTime(0, audioContext.currentTime);
-    audioMuted = true;
+  audioMuted = !unmuted; // audioMuted = true when muting, false when unmuting
+  if (masterGain) {
+    masterGain.gain.setValueAtTime(unmuted ? 1 : 0, audioContext.currentTime);
   }
 }
 
@@ -218,18 +228,8 @@ function playAudioWhenReady(audioSrc, label, markerId) {
   });
 }
 
-// ── A-Frame Component: marker-audio-handler ───────────────────────────────────
-// Dummy component — audio playback ditangani langsung via playAudioWhenReady()
-// di markerFound/markerLost listeners (initMarkerListeners).
-AFRAME.registerComponent('marker-audio-handler', {
-  schema: {
-    audioSrc: { type: 'string', default: '' },
-  },
-
-  init: function () {
-    console.log('[ar-loader] marker-audio-handler init, audioSrc:', this.data.audioSrc);
-  },
-});
+// marker-audio-handler was removed — audio playback is fully owned by
+// playAudioWhenReady() called in initMarkerListeners (markerFound/markerLost).
 
 // ── Loading Overlay UI ────────────────────────────────────────────────────────
 function showLoading() {

--- a/public/js/ar-loader.js
+++ b/public/js/ar-loader.js
@@ -81,8 +81,17 @@ function parseMarkerModelData(marker) {
 // ── Preload audio untuk satu marker ──────────────────────────────────────────
 function preloadAudioForMarker(marker) {
   var audioSrc = parseMarkerModelData(marker).audioSrc;
-  if (!audioSrc || audioElements.has(audioSrc)) return;
+  console.log('[ar-loader] preloadAudioForMarker called, audioSrc:', audioSrc);
+  if (!audioSrc) {
+    console.log('[ar-loader] No audioSrc, skipping');
+    return;
+  }
+  if (audioElements.has(audioSrc)) {
+    console.log('[ar-loader] Audio already cached:', audioSrc);
+    return;
+  }
 
+  console.log('[ar-loader] Creating new Audio element for:', audioSrc);
   var audio = new Audio();
   audio.src = audioSrc;
   audio.preload = 'auto';
@@ -92,7 +101,11 @@ function preloadAudioForMarker(marker) {
   }, false);
 
   audio.addEventListener('error', function(e) {
-    console.error('[ar-loader] Audio load failed:', audioSrc, e);
+    console.error('[ar-loader] Audio load failed:', audioSrc, 'error:', audio.error);
+  }, false);
+
+  audio.addEventListener('loadstart', function() {
+    console.log('[ar-loader] Audio load started:', audioSrc);
   }, false);
 
   audioElements.set(audioSrc, audio);
@@ -280,26 +293,45 @@ function initMarkerListeners() {
 
       // Play audio when marker found
       var audioSrc = parseMarkerModelData(marker).audioSrc;
+      console.log('[ar-loader] markerFound, audioSrc:', audioSrc);
+      console.log('[ar-loader] audioElements map size:', audioElements.size);
+      console.log('[ar-loader] audioElements keys:', Array.from(audioElements.keys()));
       if (audioSrc) {
         var audio = audioElements.get(audioSrc);
+        console.log('[ar-loader] cached audio element:', audio);
         if (audio) {
+          console.log('[ar-loader] audio state before play:', {
+            readyState: audio.readyState,
+            paused: audio.paused,
+            src: audio.src
+          });
           // Jika audio belum ready (buffering), buat element baru dan play langsung
           if (audio.readyState < 2) { // HAVE_CURRENT_DATA = 2
+            console.log('[ar-loader] Audio not ready, creating fresh Audio...');
             var freshAudio = new Audio(audioSrc);
             freshAudio.preload = 'auto';
             freshAudio.play().then(function() {
               console.log('[ar-loader] Audio playing (fresh):', audioSrc);
             }).catch(function(e) {
               console.error('[ar-loader] Audio play failed (fresh):', e);
+              console.error('[ar-loader] freshAudio error name:', e.name, 'message:', e.message);
             });
           } else {
+            console.log('[ar-loader] Audio ready, playing cached...');
             audio.currentTime = 0;
             audio.play().catch(function(e) {
               console.error('[ar-loader] Audio play failed:', e);
+              console.error('[ar-loader] audio error name:', e.name, 'message:', e.message);
             });
           }
         } else {
-          console.warn('[ar-loader] Audio element not found for:', audioSrc);
+          console.warn('[ar-loader] Audio element not found in cache, creating new...');
+          var newAudio = new Audio(audioSrc);
+          newAudio.play().then(function() {
+            console.log('[ar-loader] Audio playing (new):', audioSrc);
+          }).catch(function(e) {
+            console.error('[ar-loader] Audio play failed (new):', e);
+          });
         }
       }
     });

--- a/public/js/ar-loader.js
+++ b/public/js/ar-loader.js
@@ -12,6 +12,7 @@
 var markerVisibilityVersion = new Map(); // markerId → integer counter
 var modelStates = new Map();              // modelSrc → { loaded, object3D, animations }
 var audioElements = new Map();            // audioSrc → HTMLAudioElement
+window._arAudioElements = audioElements;  // debug: accessible from console
 var globalClock = null;
 var _arAnimationMixers = [];             // central mixer list, updated by scene component
 
@@ -75,6 +76,26 @@ function parseMarkerModelData(marker) {
     modelScale: marker.getAttribute('data-model-scale') || '1 1 1',
     modelPosition: marker.getAttribute('data-model-position') || '0 0.25 0',
   };
+}
+
+// ── Preload audio untuk satu marker ──────────────────────────────────────────
+function preloadAudioForMarker(marker) {
+  var audioSrc = parseMarkerModelData(marker).audioSrc;
+  if (!audioSrc || audioElements.has(audioSrc)) return;
+
+  var audio = new Audio();
+  audio.src = audioSrc;
+  audio.preload = 'auto';
+
+  audio.addEventListener('canplay', function() {
+    console.log('[ar-loader] Audio ready:', audioSrc);
+  }, false);
+
+  audio.addEventListener('error', function(e) {
+    console.error('[ar-loader] Audio load failed:', audioSrc, e);
+  }, false);
+
+  audioElements.set(audioSrc, audio);
 }
 
 // ── Loading Overlay UI ────────────────────────────────────────────────────────
@@ -223,6 +244,9 @@ function initMarkerListeners() {
     var markerId = marker.id;
     var modelSrc = parseMarkerModelData(marker).modelSrc;
 
+    // Preload audio SEBELUM markerFound event — agar audio ready saat marker terdeteksi
+    preloadAudioForMarker(marker);
+
     marker.addEventListener('markerFound', function () {
       var version = bumpMarkerVisibilityVersion(markerId);
       showLoading();
@@ -259,10 +283,23 @@ function initMarkerListeners() {
       if (audioSrc) {
         var audio = audioElements.get(audioSrc);
         if (audio) {
-          audio.currentTime = 0;
-          audio.play().catch(function(e) {
-            console.warn('[ar-loader] Audio play failed:', e.message);
-          });
+          // Jika audio belum ready (buffering), buat element baru dan play langsung
+          if (audio.readyState < 2) { // HAVE_CURRENT_DATA = 2
+            var freshAudio = new Audio(audioSrc);
+            freshAudio.preload = 'auto';
+            freshAudio.play().then(function() {
+              console.log('[ar-loader] Audio playing (fresh):', audioSrc);
+            }).catch(function(e) {
+              console.error('[ar-loader] Audio play failed (fresh):', e);
+            });
+          } else {
+            audio.currentTime = 0;
+            audio.play().catch(function(e) {
+              console.error('[ar-loader] Audio play failed:', e);
+            });
+          }
+        } else {
+          console.warn('[ar-loader] Audio element not found for:', audioSrc);
         }
       }
     });

--- a/public/js/ar-loader.js
+++ b/public/js/ar-loader.js
@@ -11,7 +11,12 @@
 // ── State ────────────────────────────────────────────────────────────────────
 var markerVisibilityVersion = new Map(); // markerId → integer counter
 var modelStates = new Map();              // modelSrc → { loaded, object3D, animations }
-var audioElements = new Map();            // audioSrc → HTMLAudioElement
+var audioElements = new Map();            // audioSrc → HTMLAudioElement (legacy)
+var audioBufferCache = new Map();         // audioSrc → AudioBuffer
+var audioContext = null;                  // Web Audio API context (lazy init)
+var masterGain = null;                    // GainNode untuk mute/unmute via volume
+var activeAudioSources = new Map();      // markerId → { source, startedAt }
+var audioMuted = true;                    // default muted — user harus klik tombol untuk unmute
 window._arAudioElements = audioElements;  // debug: accessible from console
 var globalClock = null;
 var _arAnimationMixers = [];             // central mixer list, updated by scene component
@@ -81,35 +86,150 @@ function parseMarkerModelData(marker) {
 // ── Preload audio untuk satu marker ──────────────────────────────────────────
 function preloadAudioForMarker(marker) {
   var audioSrc = parseMarkerModelData(marker).audioSrc;
-  console.log('[ar-loader] preloadAudioForMarker called, audioSrc:', audioSrc);
-  if (!audioSrc) {
-    console.log('[ar-loader] No audioSrc, skipping');
-    return;
-  }
-  if (audioElements.has(audioSrc)) {
-    console.log('[ar-loader] Audio already cached:', audioSrc);
-    return;
-  }
+  if (!audioSrc) return;
 
-  console.log('[ar-loader] Creating new Audio element for:', audioSrc);
-  var audio = new Audio();
-  audio.src = audioSrc;
-  audio.preload = 'auto';
-
-  audio.addEventListener('canplay', function() {
-    console.log('[ar-loader] Audio ready:', audioSrc);
-  }, false);
-
-  audio.addEventListener('error', function(e) {
-    console.error('[ar-loader] Audio load failed:', audioSrc, 'error:', audio.error);
-  }, false);
-
-  audio.addEventListener('loadstart', function() {
-    console.log('[ar-loader] Audio load started:', audioSrc);
-  }, false);
-
-  audioElements.set(audioSrc, audio);
+  // Pre-decode ke AudioBuffer — dilakukan di background saat AR scene dimuat.
+  // Setelah ini, playAudioWhenReady() akan langsung pakai cache (tanpa fetch lagi).
+  decodeAudioToBuffer(audioSrc).then(function() {
+    console.log('[ar-loader] Audio pre-decoded:', audioSrc);
+  }).catch(function(e) {
+    console.error('[ar-loader] Audio pre-decode failed:', audioSrc, e);
+    // Fallback: simpan HTML Audio element untuk fallback path
+    if (!audioElements.has(audioSrc)) {
+      var audio = new Audio(audioSrc);
+      audio.preload = 'auto';
+      audioElements.set(audioSrc, audio);
+    }
+  });
 }
+
+// ── Web Audio API Manager ─────────────────────────────────────────────────────
+// Menggunakan Web Audio API decodeAudioData — bypasses browser autoplay policy
+// karena AudioBuffer sudah di-memory sebelum play() dipanggil.
+// Ini memperbaiki masalah: "audio tidak play di detection pertama".
+function getAudioContext() {
+  if (!audioContext) {
+    audioContext = new (window.AudioContext || window.webkitAudioContext)();
+    masterGain = audioContext.createGain();
+    masterGain.connect(audioContext.destination);
+    masterGain.gain.value = 0; // start muted
+    console.log('[ar-loader] AudioContext + GainNode created, muted');
+  }
+  return audioContext;
+}
+
+// Set volume 0 (mute) atau 1 (unmute) via GainNode
+function setMasterVolume(unmuted) {
+  if (!masterGain) return;
+  if (unmuted) {
+    masterGain.gain.setValueAtTime(1, audioContext.currentTime);
+    audioMuted = false;
+  } else {
+    masterGain.gain.setValueAtTime(0, audioContext.currentTime);
+    audioMuted = true;
+  }
+}
+
+// Stop audio source yang sedang playing untuk satu marker
+function stopMarkerAudio(markerId) {
+  var active = activeAudioSources.get(markerId);
+  if (active && active.source) {
+    try { active.source.stop(0); } catch(e) {}
+    activeAudioSources.delete(markerId);
+  }
+}
+
+// Decode audio file ke AudioBuffer (sekali saja, di-cache)
+function decodeAudioToBuffer(audioSrc) {
+  return new Promise(function(resolve, reject) {
+    // Sudah di-cache → langsung resolve
+    if (audioBufferCache.has(audioSrc)) {
+      resolve(audioBufferCache.get(audioSrc));
+      return;
+    }
+
+    fetch(audioSrc).then(function(res) {
+      if (!res.ok) throw new Error('HTTP ' + res.status);
+      return res.arrayBuffer();
+    }).then(function(arrayBuffer) {
+      var ctx = getAudioContext();
+      // Decode bisa throw synchronously jika format corrupt
+      try {
+        ctx.decodeAudioData(arrayBuffer, function(buffer) {
+          audioBufferCache.set(audioSrc, buffer);
+          console.log('[ar-loader] AudioBuffer decoded + cached:', audioSrc);
+          resolve(buffer);
+        }, function(err) {
+          reject(err);
+        });
+      } catch(e) {
+        reject(e);
+      }
+    }).catch(reject);
+  });
+}
+
+// ── Play audio: Web Audio API (preferred) + HTML Audio fallback ───────────────
+function playAudioWhenReady(audioSrc, label, markerId) {
+  label = label || 'marker';
+  var markerKey = markerId || audioSrc;
+
+  // Decode dulu (dari cache atau fetch baru), play.
+  // masterGain.setVolume(0/1) handle mute/unmute — tidak perlu skip here.
+  decodeAudioToBuffer(audioSrc).then(function(buffer) {
+    var ctx = getAudioContext();
+
+    // Jika context suspended, TUNGGU sampai benar-benar aktif SEBELUM play.
+    // ctx.resume() mengembalikan promise — promise.then(...) menjamin urutan.
+    var doPlay = function () {
+      // Stop source lama jika ada (prevent double audio)
+      stopMarkerAudio(markerKey);
+
+      var source = ctx.createBufferSource();
+      source.buffer = buffer;
+      source.connect(masterGain); // 🔗 ke GainNode (bukan langsung ke destination)
+      source.start(0);
+
+      activeAudioSources.set(markerKey, { source: source });
+      console.log('[ar-loader] Audio playing (Web Audio API, ' + label + '):', audioSrc);
+    };
+
+    if (ctx.state === 'suspended') {
+      console.log('[ar-loader] AudioContext suspended — waiting for resume...');
+      ctx.resume().then(function () {
+        console.log('[ar-loader] AudioContext resumed — playing audio');
+        doPlay();
+      });
+    } else {
+      doPlay();
+    }
+
+  }).catch(function(e) {
+    console.error('[ar-loader] Web Audio failed, fallback to HTML Audio:', audioSrc, e);
+    // Fallback: HTML Audio (bisa kena autoplay block — tapi jika user sudah unmute,
+    // berarti ada gesture, jadi peluang berhasil lebih tinggi)
+    var cachedAudio = audioElements.get(audioSrc);
+    if (cachedAudio) {
+      cachedAudio.currentTime = 0;
+      cachedAudio.play().catch(function(err) {
+        console.error('[ar-loader] HTML Audio fallback also failed:', err);
+      });
+    }
+  });
+}
+
+// ── A-Frame Component: marker-audio-handler ───────────────────────────────────
+// Dummy component — audio playback ditangani langsung via playAudioWhenReady()
+// di markerFound/markerLost listeners (initMarkerListeners).
+AFRAME.registerComponent('marker-audio-handler', {
+  schema: {
+    audioSrc: { type: 'string', default: '' },
+  },
+
+  init: function () {
+    console.log('[ar-loader] marker-audio-handler init, audioSrc:', this.data.audioSrc);
+  },
+});
 
 // ── Loading Overlay UI ────────────────────────────────────────────────────────
 function showLoading() {
@@ -194,15 +314,6 @@ function loadGLB(modelSrc, markerId, visibilityVersion) {
 
         updateProgress(100);
 
-        // Download audio after GLB loaded
-        var audioSrc = parseMarkerModelData(document.getElementById(markerId)).audioSrc;
-        if (audioSrc && !audioElements.has(audioSrc)) {
-          var audio = new Audio();
-          audio.src = audioSrc;
-          audio.preload = 'auto';
-          audioElements.set(audioSrc, audio);
-        }
-
         resolve(gltf);
       },
       function (e) {
@@ -257,13 +368,20 @@ function initMarkerListeners() {
     var markerId = marker.id;
     var modelSrc = parseMarkerModelData(marker).modelSrc;
 
-    // Preload audio SEBELUM markerFound event — agar audio ready saat marker terdeteksi
+    // Pre-decode audio ke AudioBuffer saat AR scene ready
+    // Ini memastikan audio sudah di memory sebelum markerFound pertama kali fire
     preloadAudioForMarker(marker);
 
     marker.addEventListener('markerFound', function () {
       var version = bumpMarkerVisibilityVersion(markerId);
       showLoading();
       updateProgress(5);
+
+      // Play audio langsung saat marker terdeteksi — tidak perlu tunggu tick
+      var audioSrc = parseMarkerModelData(marker).audioSrc;
+      if (audioSrc) {
+        playAudioWhenReady(audioSrc, 'markerFound:' + markerId, markerId);
+      }
 
       attachModel(markerId, modelSrc);
 
@@ -290,73 +408,77 @@ function initMarkerListeners() {
         updateProgress(100);
         hideLoading();
       }
-
-      // Play audio when marker found
-      var audioSrc = parseMarkerModelData(marker).audioSrc;
-      console.log('[ar-loader] markerFound, audioSrc:', audioSrc);
-      console.log('[ar-loader] audioElements map size:', audioElements.size);
-      console.log('[ar-loader] audioElements keys:', Array.from(audioElements.keys()));
-      if (audioSrc) {
-        var audio = audioElements.get(audioSrc);
-        console.log('[ar-loader] cached audio element:', audio);
-        if (audio) {
-          console.log('[ar-loader] audio state before play:', {
-            readyState: audio.readyState,
-            paused: audio.paused,
-            src: audio.src
-          });
-          // Jika audio belum ready (buffering), buat element baru dan play langsung
-          if (audio.readyState < 2) { // HAVE_CURRENT_DATA = 2
-            console.log('[ar-loader] Audio not ready, creating fresh Audio...');
-            var freshAudio = new Audio(audioSrc);
-            freshAudio.preload = 'auto';
-            freshAudio.play().then(function() {
-              console.log('[ar-loader] Audio playing (fresh):', audioSrc);
-            }).catch(function(e) {
-              console.error('[ar-loader] Audio play failed (fresh):', e);
-              console.error('[ar-loader] freshAudio error name:', e.name, 'message:', e.message);
-            });
-          } else {
-            console.log('[ar-loader] Audio ready, playing cached...');
-            audio.currentTime = 0;
-            audio.play().catch(function(e) {
-              console.error('[ar-loader] Audio play failed:', e);
-              console.error('[ar-loader] audio error name:', e.name, 'message:', e.message);
-            });
-          }
-        } else {
-          console.warn('[ar-loader] Audio element not found in cache, creating new...');
-          var newAudio = new Audio(audioSrc);
-          newAudio.play().then(function() {
-            console.log('[ar-loader] Audio playing (new):', audioSrc);
-          }).catch(function(e) {
-            console.error('[ar-loader] Audio play failed (new):', e);
-          });
-        }
-      }
     });
 
     marker.addEventListener('markerLost', function () {
       bumpMarkerVisibilityVersion(markerId);
+
+      // Stop Web Audio source saat marker hilang
+      stopMarkerAudio(markerId);
+
+      // Pause HTML Audio fallback jika ada
+      var audioSrc = parseMarkerModelData(marker).audioSrc;
+      if (audioSrc) {
+        var audio = audioElements.get(audioSrc);
+        if (audio && !audio.paused) {
+          audio.pause();
+          audio.currentTime = 0;
+        }
+      }
+
       detachModel(markerId);
       // Pause mixer saat marker hilang agar animasi tidak jalan saat model tidak terlihat
       var cached = modelStates.get(modelSrc);
       if (cached && cached.mixer) {
         cached.mixer.timeScale = 0;
       }
-
-      // Pause audio when marker lost
-      var audioSrc = parseMarkerModelData(marker).audioSrc;
-      if (audioSrc) {
-        var audio = audioElements.get(audioSrc);
-        if (audio) {
-          audio.pause();
-        }
-      }
     });
   });
 
   console.log('[ar-loader] ' + markers.length + ' marker(s) di-register');
+}
+
+// ── Audio Toggle Button ──────────────────────────────────────────────────────
+function initAudioToggle() {
+  var btn = document.getElementById('audio-toggle');
+  if (!btn) return;
+
+  var togglePending = false;
+
+  function updateIcon() {
+    var offIcon = document.getElementById('icon-audio-off');
+    var onIcon = document.getElementById('icon-audio-on');
+    if (!audioMuted) {
+      offIcon.style.display = 'none';
+      onIcon.style.display = 'block';
+      btn.style.background = 'rgba(0,140,0,.9)';
+    } else {
+      offIcon.style.display = 'block';
+      onIcon.style.display = 'none';
+      btn.style.background = 'rgba(194,92,6,.9)';
+    }
+  }
+
+  btn.addEventListener('click', function () {
+    if (togglePending) return; // antibounce
+    togglePending = true;
+    setTimeout(function () { togglePending = false; }, 300);
+
+    var nowUnmuting = audioMuted; // capture state before toggle
+    setMasterVolume(nowUnmuting); // true = unmute (gain=1), false = mute (gain=0)
+    updateIcon();
+    console.log('[ar-loader] Audio muted:', audioMuted);
+
+    if (nowUnmuting) {
+      // User gesture — resume AudioContext
+      var ctx = getAudioContext();
+      if (ctx.state === 'suspended') {
+        ctx.resume().then(function () {
+          console.log('[ar-loader] AudioContext resumed after unmute');
+        });
+      }
+    }
+  });
 }
 
 // ── Boot ────────────────────────────────────────────────────────────────────
@@ -407,4 +529,5 @@ function onSceneReady() {
   }
   if (typeof THREE !== 'undefined') initLoaders();
   initMarkerListeners();
+  initAudioToggle();
 }

--- a/resources/views/ar-camera.blade.php
+++ b/resources/views/ar-camera.blade.php
@@ -105,7 +105,7 @@
                 data-audio-src="{{ $marker->path_audio ? '/storage/' . $marker->path_audio : '' }}"
                 data-model-scale="1 1 1" data-model-position="0 0.25 0">
                 <a-entity id="marker{{ $marker->marker_id }}-entity" position="0 0 0" scale="1 1 1" class="clickable"
-                    gesture-handler marker-audio-handler="audioSrc: {{ $marker->path_audio ? '/storage/' . $marker->path_audio : '' }}"
+                    gesture-handler>
                     @unless ($marker->path_model)
                         <a-box color="#c25c06" width="0.5" height="0.5" depth="0.5" position="0 0.25 0"
                             animation="property: rotation; to: 0 360 0; dur: 3000; loop: true; easing: linear"></a-box>

--- a/resources/views/ar-camera.blade.php
+++ b/resources/views/ar-camera.blade.php
@@ -69,6 +69,30 @@
   font-size:14px;z-index:1000;
 ">Kembali</a>
 
+    <button id="audio-toggle"
+        style="
+  position:absolute;bottom:20px;right:20px;
+  background:rgba(194,92,6,.9);border:none;border-radius:50%;
+  width:52px;height:52px;cursor:pointer;z-index:1000;
+  display:flex;align-items:center;justify-content:center;
+  box-shadow:0 2px 8px rgba(0,0,0,.4);
+" title="Toggle Audio">
+        <svg id="icon-audio-off" xmlns="http://www.w3.org/2000/svg" width="22" height="22"
+            viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round">
+            <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon>
+            <line x1="23" y1="9" x2="17" y2="15"></line>
+            <line x1="17" y1="9" x2="23" y2="15"></line>
+        </svg>
+        <svg id="icon-audio-on" xmlns="http://www.w3.org/2000/svg" width="22" height="22"
+            viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round" style="display:none">
+            <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon>
+            <path d="M15.54 8.46a5 5 0 0 1 0 7.07"></path>
+            <path d="M19.07 4.93a10 10 0 0 1 0 14.14"></path>
+        </svg>
+    </button>
+
     <a-scene embedded arjs="sourceType: webcam; detectionMode: mono_and_matrix; matrixCodeType: 3x3;"
         renderer="logarithmicDepthBuffer: true; antialias: true;" vr-mode-ui="enabled: false" gesture-detector
         id="scene" loading-screen="enabled: false">
@@ -81,7 +105,7 @@
                 data-audio-src="{{ $marker->path_audio ? '/storage/' . $marker->path_audio : '' }}"
                 data-model-scale="1 1 1" data-model-position="0 0.25 0">
                 <a-entity id="marker{{ $marker->marker_id }}-entity" position="0 0 0" scale="1 1 1" class="clickable"
-                    gesture-handler>
+                    gesture-handler marker-audio-handler="audioSrc: {{ $marker->path_audio ? '/storage/' . $marker->path_audio : '' }}"
                     @unless ($marker->path_model)
                         <a-box color="#c25c06" width="0.5" height="0.5" depth="0.5" position="0 0.25 0"
                             animation="property: rotation; to: 0 360 0; dur: 3000; loop: true; easing: linear"></a-box>
@@ -144,20 +168,6 @@
 
             document.querySelectorAll('a-marker').forEach(function(marker) {
                 marker.addEventListener('markerFound', function() {
-                    var audioSrc = parseMarkerModelData(marker).audioSrc;
-                    console.log('[ar-camera] markerFound:', marker.id, 'audioSrc:', audioSrc);
-                    if (audioSrc) {
-                        var cached = window._arAudioElements && window._arAudioElements.get(audioSrc);
-                        console.log('[ar-camera] cached audio element:', cached);
-                        if (cached) {
-                            console.log('[ar-camera] audio state:', {
-                                readyState: cached.readyState,
-                                paused: cached.paused,
-                                src: cached.src
-                            });
-                        }
-                    }
-
                     document.getElementById('marker-title').textContent = marker.getAttribute(
                         'data-marker-name');
                     document.getElementById('marker-description').textContent = marker.getAttribute(

--- a/resources/views/ar-camera.blade.php
+++ b/resources/views/ar-camera.blade.php
@@ -144,6 +144,20 @@
 
             document.querySelectorAll('a-marker').forEach(function(marker) {
                 marker.addEventListener('markerFound', function() {
+                    var audioSrc = parseMarkerModelData(marker).audioSrc;
+                    console.log('[ar-camera] markerFound:', marker.id, 'audioSrc:', audioSrc);
+                    if (audioSrc) {
+                        var cached = window._arAudioElements && window._arAudioElements.get(audioSrc);
+                        console.log('[ar-camera] cached audio element:', cached);
+                        if (cached) {
+                            console.log('[ar-camera] audio state:', {
+                                readyState: cached.readyState,
+                                paused: cached.paused,
+                                src: cached.src
+                            });
+                        }
+                    }
+
                     document.getElementById('marker-title').textContent = marker.getAttribute(
                         'data-marker-name');
                     document.getElementById('marker-description').textContent = marker.getAttribute(


### PR DESCRIPTION
## Summary

- Rewrite AR audio playback using Web Audio API (`decodeAudioData` + `BufferSourceNode`) to bypass browser autoplay policy — audio now plays on first marker detection
- Add `GainNode` (masterGain) for real-time mute/unmute via volume control instead of flag-based skipping
- Track active audio sources per marker via `activeAudioSources` Map to prevent double playback on re-detection
- Pre-decode all marker audio to `AudioBuffer` at scene init (already cached by the time `markerFound` fires)
- Add audio toggle button (bottom-right, default muted) as explicit user gesture to unlock `AudioContext`; 300ms debounce prevents rapid toggling
- Ensure `ctx.resume()` promise resolves before playing audio (`.then()` chaining guarantees ordering)
- Remove `tick()` polling from audio playback — audio is now handled directly via `markerFound`/`markerLost` event listeners
- Fix `setMasterVolume` always updating `audioMuted` flag even when `masterGain` is null (prevents UI state drift)
- Remove dead `marker-audio-handler` A-Frame component (was only logging in `init`; audio fully owned by `initMarkerListeners`)
- Fix missing `>` on `<a-entity>` tag so Blade `@unless`/`@endunless` and `<a-box>` are parsed as proper A-Frame children
- `preloadAudioForMarker`: add `URL` constructor validation + `trim` check before attempting decode; logs warning and returns early for empty/malformed `audioSrc`

## Root cause

**Original:** `audio.play()` was called on an `HTMLAudioElement` that was either not yet loaded (first detection) or blocked by browser autoplay policy since `markerFound` is a system event, not a user gesture.

**Intermediate:** `tick()` polling had a timing race — audio element was created in the rendering loop and `readyState >= 3` often wasn't met before the visibility check passed.

**Fixed:** Web Audio API decodes the audio file to an `AudioBuffer` at scene init (before any marker is detected). When a marker is found, `source.start()` plays from an already-decoded buffer — no network, no timing race, no autoplay block. `GainNode` handles mute/unmute instantly without stopping/restarting sources.

## Audio graph

```
AudioBufferSourceNode → masterGain → AudioContext.destination
                                  ↑
                            gain = 0 (mute) or 1 (unmute)
```

## Test plan

- [x] First marker detection — audio plays immediately after unmute
- [x] Mute/unmute toggle — instant silence/volume via GainNode
- [x] Marker re-detected — no double audio (old source stopped before new one starts)
- [x] Marker lost — audio stops immediately
- [x] Audio toggle button shows correct icon state (speaker-off orange / speaker-on green)
- [x] No JS errors in console on markerFound/markerLost

Closes #10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * On-screen audio toggle with mute/unmute icons for the AR view.
  * Faster, more reliable marker audio: playback begins immediately when a marker is detected and uses background audio buffering.
  * Per-marker audio preloading and improved playback management to avoid overlap.

* **Bug Fixes**
  * Deterministic stop of marker audio when markers are lost to prevent lingering playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->