### PR TITLE
Fix AR audio toggle button icon not changing on mobile

### DIFF
--- a/public/js/ar-loader.js
+++ b/public/js/ar-loader.js
@@ -16,7 +16,7 @@ var audioBufferCache = new Map();         // audioSrc → AudioBuffer
 var audioContext = null;                  // Web Audio API context (lazy init)
 var masterGain = null;                    // GainNode untuk mute/unmute via volume
 var activeAudioSources = new Map();      // markerId → { source, startedAt }
-var audioMuted = true;                    // default muted — user harus klik tombol untuk unmute
+var audioMuted = false;                  // default unmuted
 window._arAudioElements = audioElements;  // debug: accessible from console
 var globalClock = null;
 var _arAnimationMixers = [];             // central mixer list, updated by scene component
@@ -125,8 +125,8 @@ function getAudioContext() {
     audioContext = new (window.AudioContext || window.webkitAudioContext)();
     masterGain = audioContext.createGain();
     masterGain.connect(audioContext.destination);
-    masterGain.gain.value = 0; // start muted
-    console.log('[ar-loader] AudioContext + GainNode created, muted');
+    masterGain.gain.value = audioMuted ? 0 : 1; // start unmuted (default)
+    console.log('[ar-loader] AudioContext + GainNode created, ' + (audioMuted ? 'muted' : 'unmuted'));
   }
   return audioContext;
 }
@@ -442,6 +442,9 @@ function initMarkerListeners() {
 function initAudioToggle() {
   var btn = document.getElementById('audio-toggle');
   if (!btn) return;
+
+  // Sinkronkan icon dengan state awal audio (penting untuk mobile: AudioContext lazy init)
+  updateIcon();
 
   var togglePending = false;
 

--- a/resources/views/ar-camera.blade.php
+++ b/resources/views/ar-camera.blade.php
@@ -72,21 +72,22 @@
     <button id="audio-toggle"
         style="
   position:absolute;bottom:20px;right:20px;
-  background:rgba(194,92,6,.9);border:none;border-radius:50%;
+  background:rgba(0,140,0,.9);border:none;border-radius:50%;
   width:52px;height:52px;cursor:pointer;z-index:1000;
   display:flex;align-items:center;justify-content:center;
   box-shadow:0 2px 8px rgba(0,0,0,.4);
 " title="Toggle Audio">
         <svg id="icon-audio-off" xmlns="http://www.w3.org/2000/svg" width="22" height="22"
             viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2"
-            stroke-linecap="round" stroke-linejoin="round">
+            stroke-linecap="round" stroke-linejoin="round"
+            style="display:none">
             <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon>
             <line x1="23" y1="9" x2="17" y2="15"></line>
             <line x1="17" y1="9" x2="23" y2="15"></line>
         </svg>
         <svg id="icon-audio-on" xmlns="http://www.w3.org/2000/svg" width="22" height="22"
             viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2"
-            stroke-linecap="round" stroke-linejoin="round" style="display:none">
+            stroke-linecap="round" stroke-linejoin="round">
             <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon>
             <path d="M15.54 8.46a5 5 0 0 1 0 7.07"></path>
             <path d="M19.07 4.93a10 10 0 0 1 0 14.14"></path>


### PR DESCRIPTION
## Summary
- Ubah default audio dari **mute** ke **unmute** (`audioMuted = false`, `masterGain.gain.value = 1`)
- Sinkronkan icon saat `initAudioToggle()` dipanggil agar icon berubah saat inisialisasi (memperbaiki bug di mobile: AudioContext dibuat lazy)
- Update default button background dari orange ke hijau dan swap visibility icon di HTML agar sesuai default unmute

## Test plan
- [ ] Saat page load, icon yang terlihat adalah **speaker + waves** (unmute)
- [ ] Saat ditekan, icon berubah menjadi **speaker + X** (mute)
- [ ] Saat ditekan lagi, icon berubah kembali menjadi **speaker + waves**
- [ ] Audio play/stop berfungsi benar
- [ ] Test di Chrome mobile dan Safari iOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Audio now starts unmuted by default instead of muted
  * Fixed audio toggle button UI to properly synchronize with initial audio state
  * Updated audio toggle button styling for improved visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->